### PR TITLE
Add support to dynamic connection params

### DIFF
--- a/lib/src/socket_options.dart
+++ b/lib/src/socket_options.dart
@@ -7,10 +7,12 @@ class PhoenixSocketOptions {
     Duration heartbeat,
     this.reconnectDelays = const [],
     this.params,
+    this.dynamicParams,
   })  : _timeout = timeout ?? Duration(seconds: 10),
         _heartbeat = heartbeat ?? Duration(seconds: 30) {
+    assert(!(params != null && dynamicParams != null),
+        "Can't set both params and dynamicParams");
     params ??= {};
-    params['vsn'] = '2.0.0';
   }
 
   final Duration _timeout;
@@ -26,5 +28,16 @@ class PhoenixSocketOptions {
   final List<Duration> reconnectDelays;
 
   /// Parameters sent to your Phoenix backend on connection.
+  /// Use [dynamicParams] if your params are dynamic.
   Map<String, String> params;
+
+  /// Will be called to get fresh params before each connection attempt.
+  Future<Map<String, String>> Function() dynamicParams;
+
+  /// Get connection params.
+  Future<Map<String, String>> getParams() async {
+    var res = dynamicParams != null ? await dynamicParams() : params;
+    res['vsn'] = '2.0.0';
+    return res;
+  }
 }


### PR DESCRIPTION
Phoenix.js support dynamic connection params via a closure :
https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L374

This pr adds a `Future<Map<String, String>> Function() dynamicParams` option to `PhoenixSocketOptions`.
